### PR TITLE
Change length primary key

### DIFF
--- a/migrate/versioning/schema.py
+++ b/migrate/versioning/schema.py
@@ -174,7 +174,7 @@ class ControlledSchema(object):
 
         table = Table(
             tname, meta,
-            Column('repository_id', String(250), primary_key=True),
+            Column('repository_id', String(128), primary_key=True),
             Column('repository_path', Text),
             Column('version', Integer), )
 


### PR DESCRIPTION
For mariadb 10.* was error:
1071 specified key was too long max key length is 767 bytes 
when create table.
Will be change length primary key.